### PR TITLE
DRUP-530 Update composer.json to allow installing swagger ui library to web/libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,21 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "swagger-api/swagger-ui",
+        "version": "3.22.0",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://github.com/swagger-api/swagger-ui/archive/v3.22.0.zip",
+          "type": "zip"
+        },
+        "require": {
+          "composer/installers": "^1.2.0"
+        }
+      }
     }
   ],
   "config": {


### PR DESCRIPTION
An adjustment to the root composer is needed to install a library to _web/libraries_ instead of the vendor directory. This is needed to support installing the _swagger_ui_formatter_ module out of the box on the kickstart profile.
See https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/25.