### PR TITLE
DRUP-682: Use apigee/apigee_devportal_kickstart release versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "composer/installers": "^1.2",
     "cweagans/composer-patches": "^1.6.5",
     "drupal-composer/drupal-scaffold": "^2.5",
-    "apigee/apigee_devportal_kickstart": "dev-8.x-1.x",
+    "apigee/apigee_devportal_kickstart": "^1.0.0",
     "php": "^7.1"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
Modify apigee/apigee_devportal_kickstart to pull down versioned 1.0.0 releases from packagist