### PR TITLE
DRUP-746: Add drush

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "drupal-composer/drupal-scaffold": "^2.5",
     "apigee/apigee_devportal_kickstart": "^1.0.0",
     "php": "^7.1",
-    "drush/drush": "^9.0.0"
+    "drush/drush": "~8"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "cweagans/composer-patches": "^1.6.5",
     "drupal-composer/drupal-scaffold": "^2.5",
     "apigee/apigee_devportal_kickstart": "^1.0.0",
-    "php": "^7.1"
+    "php": "^7.1",
+    "drush/drush": "^9.0.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
Project should have Drush installed out of the box to make our documentation on steps easier, such as our API Docs CI setup