### PR TITLE
[DRUP-816] Remove Swagger UI in favor of SmartDocs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,6 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
-    },
-    {
-      "type": "package",
-      "package": {
-        "name": "swagger-api/swagger-ui",
-        "version": "3.22.0",
-        "type": "drupal-library",
-        "dist": {
-          "url": "https://github.com/swagger-api/swagger-ui/archive/v3.22.0.zip",
-          "type": "zip"
-        },
-        "require": {
-          "composer/installers": "^1.2.0"
-        }
-      }
     }
   ],
   "config": {


### PR DESCRIPTION
Part of https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/119.