### PR TITLE
#13: Add Apigee Monetization and dependencies for the Add Credit submodule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
     "cweagans/composer-patches": "^1.6.5",
     "drupal-composer/drupal-scaffold": "^2.5",
     "apigee/apigee_devportal_kickstart": "^1.0.0",
+    "drupal/apigee_m10n": "^1.0.0",
+    "drupal/commerce": "^2.13",
     "php": "^7.1",
     "drush/drush": "~8"
   },


### PR DESCRIPTION
The `apigee_m10n` module contains a submodule called `apigee_m10n_add_credit`.  That submodule is optional, and it requires the Commerce module.  This PR adds both to the Kickstart.

Fixes #13.