### PR TITLE
[#16] Remove drush 8 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "apigee/apigee_devportal_kickstart": "^1.0.0",
     "drupal/apigee_m10n": "^1.0.0",
     "drupal/commerce": "^2.13",
-    "php": "^7.1",
-    "drush/drush": "~8"
+    "php": "^7.1"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
Fixes #16 

(Note: Blocked by https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/259)