### PR TITLE
New branch for Drupal 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ We'd love to accept your patches and contributions to this project. Make sure to
 
 ## Support
 
-This project, which integrates Drupal 8 with Apigee Edge, is supported by Google.
+This project, which integrates Drupal 8/9 with Apigee Edge, is supported by Google.

--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
     }
   ],
   "require": {
-    "composer/installers": "^1.2",
-    "drupal/core-composer-scaffold": "^8.8",
-    "drupal/core-project-message": "^8.8",
-    "drupal/core-recommended": "^8.8",
-    "apigee/apigee_devportal_kickstart": "^1.0.0",
-    "drupal/apigee_m10n": "^1.0.0",
-    "drupal/commerce": "^2.16",
-    "php": "^7.2"
+    "composer/installers": "^1.9",
+    "drupal/core-composer-scaffold": "^9",
+    "drupal/core-project-message": "^9",
+    "drupal/core-recommended": "^9",
+    "apigee/apigee_devportal_kickstart": "^1.21.0",
+    "drupal/apigee_m10n": "^1.7",
+    "drupal/commerce": "^2.21",
+    "php": "^7.3"
   },
   "require-dev": {
-    "drupal/core-dev": "^8.8",
-    "drush/drush": "^9.7"
+    "drupal/core-dev": "^9",
+    "drush/drush": "^10"
   },
   "conflict": {
     "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,30 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "furf/jquery-ui-touch-punch",
+        "version": "dev-master",
+        "type": "drupal-library",
+        "dist": {
+          "url": "https://github.com/furf/jquery-ui-touch-punch/archive/master.zip",
+          "type": "zip"
+        }
+      }
     }
   ],
   "require": {
+    "php": "^7.3",
+    "apigee/apigee_devportal_kickstart": "^1.21.0",
     "composer/installers": "^1.9",
+    "drupal/apigee_m10n": "^1.7",
+    "drupal/commerce": "^2.21",
     "drupal/core-composer-scaffold": "^9",
     "drupal/core-project-message": "^9",
     "drupal/core-recommended": "^9",
-    "apigee/apigee_devportal_kickstart": "^1.21.0",
-    "drupal/apigee_m10n": "^1.7",
-    "drupal/commerce": "^2.21",
-    "php": "^7.3"
+    "furf/jquery-ui-touch-punch": "dev-master"
   },
   "require-dev": {
     "drupal/core-dev": "^9",


### PR DESCRIPTION
Closes #28. Updates packages dependencies to D9 compatible versions, following the same guidelines as [drupal/recommended-project](https://github.com/drupal/recommended-project/blob/9.0.x/composer.json).

To test: Clone PR code and run composer install, and install Drupal as usual. End result should be a working D9 Kickstart site.