### PR TITLE
Composer v2.2 prompts to authorize plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "furf/jquery-ui-touch-punch": "dev-master"
   },
   "require-dev": {
+    "apigee/apigee-mock-client-php": "^1.1",
     "drupal/core-dev": "^9",
     "drush/drush": "^10"
   },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,14 @@
   "prefer-stable": true,
   "config": {
     "sort-packages": true,
-    "process-timeout": 0
+    "process-timeout": 0,
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "cweagans/composer-patches": true,
+      "composer/installers": true,
+      "drupal/core-composer-scaffold": true,
+      "drupal/core-project-message": true
+    }
   },
   "extra": {
     "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "drupal/core-composer-scaffold": "^9",
     "drupal/core-project-message": "^9",
     "drupal/core-recommended": "^9",
+    "drupal/google_analytics": "^3.1",
     "drupal/jsonapi_extras": "^3.17",
     "drupal/smtp": "^1.0",
     "furf/jquery-ui-touch-punch": "dev-master"


### PR DESCRIPTION
Fixes #49 

References:
https://github.com/composer/composer/releases/tag/2.2.0
https://getcomposer.org/doc/06-config.md#allow-plugins