### PR TITLE
Deprecated 'serializer.normalizer.content_entity.jsonapi_extras' service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,8 @@
           "Support entities that are neither content nor config entities":"https://www.drupal.org/files/issues/2020-12-02/3042467-50.patch"
       },
       "drupal/jsonapi_extras":{
-          "JSON APIS EXTRAS BULK PATCH": "https://www.drupal.org/files/issues/2020-02-20/add-enable-disable-all-buttons--2896799--10.patch"
+          "JSON APIS EXTRAS BULK PATCH": "https://www.drupal.org/files/issues/2020-02-20/add-enable-disable-all-buttons--2896799--10.patch",
+          "Jsonapi_extra installation issue due to 3042467-50.patch": "https://github.com/apigee/apigee-devportal-kickstart-drupal/files/9189452/patch.569-1.txt"
       }
     },
     "patchLevel": {


### PR DESCRIPTION
Closes #53 

Fix jsonapi_extra module installation issue and deprecated `serializer.normalizer.content_entity.jsonapi_extras` service.
Closely related to https://www.drupal.org/project/drupal/issues/3042467

Originally issue - https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/569