### PR TITLE
Fix UnmetDependenciesException error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,10 @@
     "drupal/core-composer-scaffold": "^9",
     "drupal/core-project-message": "^9",
     "drupal/core-recommended": "^9",
+    "drupal/ctools": "4.0.0",
     "drupal/google_analytics": "^3.1",
     "drupal/jsonapi_extras": "^3.17",
+    "drupal/pathauto": "1.10",
     "drupal/smtp": "^1.0",
     "furf/jquery-ui-touch-punch": "dev-master"
   },

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,8 @@
     "drupal/core-composer-scaffold": "^9",
     "drupal/core-project-message": "^9",
     "drupal/core-recommended": "^9",
-    "drupal/ctools": "4.0.0",
     "drupal/google_analytics": "^3.1",
     "drupal/jsonapi_extras": "^3.17",
-    "drupal/pathauto": "1.10",
     "drupal/smtp": "^1.0",
     "furf/jquery-ui-touch-punch": "dev-master"
   },
@@ -47,7 +45,9 @@
     "drush/drush": "^11"
   },
   "conflict": {
-    "drupal/drupal": "*"
+    "drupal/drupal": "*",
+    "drupal/ctools": ">=4.0.1",
+    "drupal/pathauto": ">=1.11"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
Resolves #55 

This PR resolves the `UnmetDependenciesException` error while installing kickstart, 

However, we need to resolve the compatibility issue with pathauto v 8.x-1.11 and ctools 4.0.1