### PR TITLE
Bump version requirement for php and m10n

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     }
   ],
   "require": {
-    "php": "~8.1.0 || ~8.1.2",
+    "php": "~8.1.0 || ~8.2.0",
     "apigee/apigee_devportal_kickstart": "^2",
     "composer/installers": "^1.9",
     "drupal/apigee_m10n": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     }
   ],
   "require": {
-    "php": "~8.1.0",
+    "php": "~8.1.0 || ~8.1.2",
     "apigee/apigee_devportal_kickstart": "^2",
     "composer/installers": "^1.9",
-    "drupal/apigee_m10n": "^2.1.0",
+    "drupal/apigee_m10n": "^2.1.1",
     "drupal/commerce": "^2.36",
     "drupal/core-composer-scaffold": "^10",
     "drupal/core-project-message": "^10",


### PR DESCRIPTION
Bump version requirement for php and m10n which support PHP 8.2