### PR TITLE
Patch to fix installation error due to missing synthetic service kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,8 @@
       },
       "drupal/jsonapi_extras":{
           "JSON APIS EXTRAS BULK PATCH": "https://www.drupal.org/files/issues/2024-06-07/add-enable-disable-all-buttons--2896799--32.patch",
-          "Jsonapi_extra installation issue due to 3042467-50.patch": "https://github.com/apigee/apigee-devportal-kickstart-drupal/files/9189452/patch.569-1.txt"
+          "Jsonapi_extra installation issue due to 3042467-50.patch": "https://github.com/apigee/apigee-devportal-kickstart-drupal/files/9189452/patch.569-1.txt",
+        "Fixes installation error due to missing synthetic service kernel": "https://www.drupal.org/files/issues/2025-02-21/jsonapi_extras--2025-02-21--3508142--mr-65.patch"
       }
     },
     "patchLevel": {


### PR DESCRIPTION
Fixes https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/733 