### PR TITLE
update the core patch for entity support (Issue #3042467)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
     "enable-patching": true,
     "patches": {
       "drupal/core": {
-          "Support entities that are neither content nor config entities":"https://www.drupal.org/files/issues/2020-12-02/3042467-50.patch",
+          "Support entities that are neither content nor config entities":"https://www.drupal.org/files/issues/2026-02-06/drupal-support_entities_11.3.x_backport_MR3548-3042467-94.patch",
           "Fixes TypeError Html::escape()": "https://www.drupal.org/files/issues/2024-11-07/TypeError_htmlspecialchars_ArgumentNustBeTypeString_ArrayGiven-3352384-62.patch"
       },
       "drupal/jsonapi_extras":{


### PR DESCRIPTION
The old patch was failing to apply during the installation of the Apigee Devportal Kickstart Drupal profile on Drupal 11. This updated patc resolves the installation failure.

Partial Patch Fix: #81 

Other Partial Patch Fix is here: https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/780