### PR TITLE
Remove outdated patch link for jsonapi_extras as module is installing as expected without any issue 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,8 +99,7 @@
           "Support entities that are neither content nor config entities":"https://www.drupal.org/files/issues/2020-12-02/3042467-50.patch"
       },
       "drupal/jsonapi_extras":{
-          "JSON APIS EXTRAS BULK PATCH": "https://www.drupal.org/files/issues/2024-06-07/add-enable-disable-all-buttons--2896799--32.patch",
-          "Jsonapi_extra installation issue due to 3042467-50.patch": "https://github.com/apigee/apigee-devportal-kickstart-drupal/files/9189452/patch.569-1.txt"
+          "JSON APIS EXTRAS BULK PATCH": "https://www.drupal.org/files/issues/2024-06-07/add-enable-disable-all-buttons--2896799--32.patch"
       }
     },
     "patchLevel": {


### PR DESCRIPTION
Fix: #80 

Originial issue Mentioned Here: #53 