### PR TITLE
Add replacements for Drupal modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,12 @@
     "furf/jquery-ui-touch-punch": "dev-master",
     "drupal/adminimal_admin_toolbar": "^1.0@dev"
   },
+  "replace": {
+    "drupal/color": "*",
+    "drupal/forum": "*",
+    "drupal/hal": "*",
+    "drupal/tour": "*"
+  },
   "require-dev": {
     "apigee/apigee-mock-client-php": "^1.1.4",
     "drupal/core-dev": "^10.6",


### PR DESCRIPTION
Added replacements for Drupal modules in composer.json.

**Error:**
Running command : `create-project apigee/devportal-kickstart-project:10.x-dev MY_PROJECT --no-interaction`
Creating a "apigee/devportal-kickstart-project:10.x-dev" project at "./MY_PROJECT"

> Installing apigee/devportal-kickstart-project (10.x-dev 3721750ffd8828293f3389da5a2b997fb39aee12)
>   - Downloading apigee/devportal-kickstart-project (10.x-dev 3721750)
>   - Installing apigee/devportal-kickstart-project (10.x-dev 3721750): Extracting archive
> Created project in /Applications/MAMP/htdocs/release/MY_PROJECT
> Loading composer repositories with package information
> Updating dependencies
> Your requirements could not be resolved to an installable set of packages.
> 
>   Problem 1
>     - Root composer.json requires apigee/apigee_devportal_kickstart ^3.1.0 -> satisfiable by apigee/apigee_devportal_kickstart[3.1.0, 3.x-dev].
>     - apigee/apigee_devportal_kickstart[3.1.0, ..., 3.x-dev] require drupal/forum ^1.0 -> satisfiable by drupal/forum[1.0.0, ..., 1.x-dev].
>     - drupal/core 11.3.12 requires drupal/core-composer-scaffold 11.3.12 -> found drupal/core-composer-scaffold[11.3.12] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.3.x-dev requires drupal/core-composer-scaffold 11.3.x-dev -> found drupal/core-composer-scaffold[11.3.x-dev] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.4.0-rc1 requires drupal/core-composer-scaffold 11.4.0-rc1 -> found drupal/core-composer-scaffold[11.4.0-rc1] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.4.0-rc2 requires drupal/core-composer-scaffold 11.4.0-rc2 -> found drupal/core-composer-scaffold[11.4.0-rc2] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.4.0-beta1 requires drupal/core-composer-scaffold 11.4.0-beta1 -> found drupal/core-composer-scaffold[11.4.0-beta1] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.4.x-dev requires drupal/core-composer-scaffold 11.4.x-dev -> found drupal/core-composer-scaffold[11.4.x-dev] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 11.x-dev requires drupal/core-composer-scaffold 11.x-dev -> found drupal/core-composer-scaffold[11.x-dev] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core 12.x-dev requires drupal/core-composer-scaffold 12.x-dev -> found drupal/core-composer-scaffold[dev-main, 12.x-dev (alias of dev-main)] but it conflicts with your root composer.json require (^10.6).
>     - drupal/core[8.0.x-dev, ..., 8.3.x-dev] require zendframework/zend-feed ~2.4 -> satisfiable by laminas/laminas-feed[2.12.0, ..., 2.27.x-dev], zendframework/zend-feed[2.10.3, ..., 2.13.x-dev].
>     - drupal/core[8.4.x-dev, ..., 8.7.x-dev] require zendframework/zend-feed ^2.4 -> satisfiable by laminas/laminas-feed[2.12.0, ..., 2.27.x-dev], zendframework/zend-feed[2.10.3, ..., 2.13.x-dev].
>     - drupal/core 8.8.x-dev requires zendframework/zend-feed ^2.12 -> satisfiable by laminas/laminas-feed[2.12.0, ..., 2.27.x-dev], zendframework/zend-feed[2.12.0, 2.12.x-dev, 2.13.x-dev].
>     - drupal/core 8.9.x-dev requires laminas/laminas-diactoros ^1.8 -> found laminas/laminas-diactoros[1.8.0, ..., 1.8.7p2] but these were not loaded, because they are affected by security advisories ("PKSA-yg4s-vh6g-jnyh", "PKSA-wdyb-c3m7-9v88"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
>     - drupal/core 9.0.x-dev requires php ^7.3 -> your php version (8.4.19) does not satisfy that requirement.
>     - drupal/core[9.1.x-dev, ..., 9.3.x-dev] require laminas/laminas-diactoros ^2.1 -> satisfiable by laminas/laminas-diactoros[2.4.x-dev, ..., 2.26.x-dev], longwave/laminas-diactoros[2.14.x-dev].
>     - drupal/forum 1.0.0 requires drupal/core ^8 -> satisfiable by drupal/core[8.0.x-dev, ..., 8.9.x-dev].
>     - drupal/forum[1.0.1, ..., 1.x-dev] require drupal/history * -> satisfiable by drupal/core[8.0.x-dev, ..., 8.9.x-dev, 9.0.x-dev, 9.1.x-dev, 9.2.x-dev, 9.3.x-dev], drupal/history[dev-1.x, 1.0.0, 1.x-dev].
>     - drupal/history[dev-1.x, 1.0.0, ..., 1.x-dev] require drupal/core >11.3 -> satisfiable by drupal/core[11.3.12, ..., 11.x-dev, 12.x-dev (alias of dev-main)].
>     - laminas/laminas-diactoros[2.7.x-dev, ..., 2.14.x-dev] require php ^7.3 || ~8.0.0 || ~8.1.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-diactoros[2.15.x-dev, ..., 2.17.x-dev] require php ^7.4 || ~8.0.0 || ~8.1.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-diactoros[2.18.1, ..., 2.25.x-dev] require php ~8.0.0 || ~8.1.0 || ~8.2.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-diactoros[2.26.0, ..., 2.26.x-dev] require php ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-diactoros 2.4.x-dev requires php ^7.1 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-diactoros[2.5.x-dev, ..., 2.6.x-dev] require php ^7.3 || ~8.0.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-feed[2.13.0, ..., 2.14.x-dev] require php ^7.3 || ~8.0.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - laminas/laminas-feed[2.12.0, ..., 2.12.x-dev] require php ^5.6 || ^7.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - zendframework/zend-feed[2.10.3, ..., 2.13.x-dev] require php ^5.6 || ^7.0 -> your php version (8.4.19) does not satisfy that requirement.
>     - longwave/laminas-diactoros 2.14.x-dev requires php ^7.3 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 -> your php version (8.4.19) does not satisfy that requirement.